### PR TITLE
feat: `onEsc`

### DIFF
--- a/src/__tests__/on-esc.test.ts
+++ b/src/__tests__/on-esc.test.ts
@@ -8,13 +8,12 @@ afterEach(() => {
 describe("onEsc", () => {
   it("calls the provided function", () => {
     const fn = jest.fn();
-    const handler = onEsc(fn);
+
+    onEsc(fn);
 
     document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
 
     expect(fn).toHaveBeenCalled();
-
-    document.removeEventListener("keydown", handler);
   });
 
   it("removes the event listener", () => {

--- a/src/__tests__/on-esc.test.ts
+++ b/src/__tests__/on-esc.test.ts
@@ -1,0 +1,57 @@
+import { tags, mount } from "@tentjs/tent";
+import { onEsc } from "../on-esc";
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("onEsc", () => {
+  it("calls the provided function", () => {
+    const fn = jest.fn();
+    const handler = onEsc(fn);
+
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+
+    expect(fn).toHaveBeenCalled();
+
+    document.removeEventListener("keydown", handler);
+  });
+
+  it("removes the event listener", () => {
+    const fn = jest.fn();
+
+    onEsc(fn, { cleanup: true });
+
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+
+    expect(fn).toHaveBeenCalled();
+
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("it calls and removes handler in a component", () => {
+    const handler = jest.fn();
+
+    const TestComponent = {
+      view() {
+        return tags.div([], {
+          mounted() {
+            onEsc(handler, { cleanup: true });
+          },
+        });
+      },
+    };
+
+    mount(document.body, TestComponent);
+
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+
+    expect(handler).toHaveBeenCalled();
+
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,9 @@
 import { bind } from "./bind";
 import { on, type OnEvents } from "./on";
+import { onEsc } from "./on-esc";
 import { classes } from "./classes";
 import { ternary } from "./ternary";
 
 import type { FormEvent } from "./types";
 
-export { bind, on, classes, ternary, type OnEvents, type FormEvent };
+export { bind, on, onEsc, classes, ternary, type OnEvents, type FormEvent };

--- a/src/on-esc.ts
+++ b/src/on-esc.ts
@@ -18,14 +18,14 @@ type Options = {
  * ```
  */
 function onEsc(fn: (e: KeyboardEvent) => void, options?: Options) {
-  const handler = (e: KeyboardEvent) => {
+  function handler(e: KeyboardEvent) {
     if (e.key === "Escape") {
       fn(e);
       if (options?.cleanup) {
         document.removeEventListener("keydown", handler);
       }
     }
-  };
+  }
 
   document.addEventListener("keydown", handler);
 }

--- a/src/on-esc.ts
+++ b/src/on-esc.ts
@@ -28,8 +28,6 @@ function onEsc(fn: (e: KeyboardEvent) => void, options?: Options) {
   };
 
   document.addEventListener("keydown", handler);
-
-  return handler;
 }
 
 export { onEsc };

--- a/src/on-esc.ts
+++ b/src/on-esc.ts
@@ -1,16 +1,13 @@
 type Options = {
   /**
-   * If `true`, the event listener will be removed after the event handler is called.
-   * Remember to set this to `true`, if you remove elements from the DOM, to avoid memory leaks.
+   * Removes the event listener after the handler is executed.
+   * Set this to `true` if you remove the dependent element from the DOM.
    */
   cleanup?: boolean;
 };
 
 /**
  * Listens for the `Escape` key press on the `document` and executes a handler function.
- *
- * This is used for closing modals, dialogs, etc.. If you are listening on a specific input element,
- * you should use the `keydown` event listener directly on that element.
  *
  * @param {function} fn - The event handler.
  * @param {Options} options

--- a/src/on-esc.ts
+++ b/src/on-esc.ts
@@ -1,7 +1,7 @@
 type Options = {
   /**
    * Removes the event listener after the handler is executed.
-   * Set this to `true` if you remove the dependent element from the DOM.
+   * Set this to `true` if you remove the dependent element from the DOM to avoid memory leaks.
    */
   cleanup?: boolean;
 };

--- a/src/on-esc.ts
+++ b/src/on-esc.ts
@@ -1,17 +1,19 @@
 type Options = {
+  /**
+   * If `true`, the event listener will be removed after the event handler is called.
+   * Remember to set this to `true`, if you remove elements from the DOM, to avoid memory leaks.
+   */
   cleanup?: boolean;
 };
 
 /**
- * Listens for the `Escape` key press on the `document` and executes a function.
+ * Listens for the `Escape` key press on the `document` and executes a handler function.
  *
- * This is used for closing modals, dialogs, etc.. If you are listening on a specific element,
+ * This is used for closing modals, dialogs, etc.. If you are listening on a specific input element,
  * you should use the `keydown` event listener directly on that element.
  *
- * Remember to set the `cleanup` parameter to `true`, if you use this function to close a modals, dialogs, etc., to avoid memory leaks.
- *
- * @param {function} fn - The function to execute.
- * @param {boolean} cleanup - Whether to remove the event listener after the function has been executed.
+ * @param {function} fn - The event handler.
+ * @param {Options} options
  *
  * @example
  * ```ts

--- a/src/on-esc.ts
+++ b/src/on-esc.ts
@@ -1,0 +1,36 @@
+type Options = {
+  cleanup?: boolean;
+};
+
+/**
+ * Listens for the `Escape` key press on the `document` and executes a function.
+ *
+ * This is used for closing modals, dialogs, etc.. If you are listening on a specific element,
+ * you should use the `keydown` event listener directly on that element.
+ *
+ * Remember to set the `cleanup` parameter to `true`, if you use this function to close a modals, dialogs, etc., to avoid memory leaks.
+ *
+ * @param {function} fn - The function to execute.
+ * @param {boolean} cleanup - Whether to remove the event listener after the function has been executed.
+ *
+ * @example
+ * ```ts
+ * onEsc((e) => console.log("Escape key pressed", e));
+ * ```
+ */
+function onEsc(fn: (e: KeyboardEvent) => void, options?: Options) {
+  const handler = (e: KeyboardEvent) => {
+    if (e.key === "Escape") {
+      fn(e);
+      if (options?.cleanup) {
+        document.removeEventListener("keydown", handler);
+      }
+    }
+  };
+
+  document.addEventListener("keydown", handler);
+
+  return handler;
+}
+
+export { onEsc };


### PR DESCRIPTION
## Description

This is a proposal for adding an `onEsc` helper function, that binds an event on `document`, which will fire an event handler passed as the first argument. Second argument contains options with one option `cleanup`.

## Usage

```ts
const Modal = {
  view() {
    return div("I am an example modal");
  },
  mounted({ el }) {
    // Run the handler calling `el.remove()` on `Escape`,
    // and, remove the event listener when that handler is fired.
    onEsc(() => el.remove(), { cleanup: true });
  },
};
```