### PR TITLE
feat: add `mountAll`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,6 @@ jobs:
 
       - name: Run tests
         run: npm run test
+
+      - name: Check JSR
+        run: npm run jsr:check

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "watch": "parcel watch",
     "build": "rm -rf .parcel-cache && parcel build",
     "test": "jest",
+    "jsr:check": "npx jsr publish --dry-run",
+    "jsr:publish": "npx jsr publish",
     "release": "npm run build && npm publish --access public"
   },
   "publishConfig": {
@@ -19,11 +21,7 @@
     "type": "git",
     "url": "git+https://github.com/tentjs/helpers.git"
   },
-  "keywords": [
-    "tent.js",
-    "helpers",
-    "typescript"
-  ],
+  "keywords": ["tent.js", "helpers", "typescript"],
   "author": "sebkolind <sks1993@gmail.com>",
   "license": "MIT",
   "bugs": {

--- a/src/__tests__/mount-all.test.ts
+++ b/src/__tests__/mount-all.test.ts
@@ -1,4 +1,4 @@
-import { tags, type Component } from "@tentjs/tent";
+import { tags } from "@tentjs/tent";
 import { getByText } from "@testing-library/dom";
 import { mountAll } from "../mount-all";
 
@@ -16,16 +16,24 @@ afterEach(() => {
 
 describe("mountAll", () => {
   it("mounts all components in the record", () => {
-    const components: Record<string, Component> = {
-      "#component-1": { view: () => tags.div("Component 1") },
-      "#component-2": { view: () => tags.div("Component 2") },
-      "#component-3": { view: () => tags.div("Component 3") },
-      "#component-4": { view: () => tags.div("Component 4") },
-    };
+    const components = [
+      {
+        target: "#component-1",
+        component: { view: () => tags.div("Component 1") },
+      },
+      {
+        target: "#component-2",
+        component: { view: () => tags.div("Component 2") },
+      },
+      {
+        target: "#component-3",
+        component: { view: () => tags.div("Component 3") },
+      },
+    ];
 
     mountAll(components);
 
-    for (let i = 1; i <= 4; i++) {
+    for (let i = 1; i <= 3; i++) {
       expect(getByText(document.body, `Component ${i}`)).toBeDefined();
     }
   });

--- a/src/__tests__/mount-all.test.ts
+++ b/src/__tests__/mount-all.test.ts
@@ -1,0 +1,32 @@
+import { tags, type Component } from "@tentjs/tent";
+import { getByText } from "@testing-library/dom";
+import { mountAll } from "../mount-all";
+
+beforeEach(() => {
+  for (let i = 1; i <= 4; i++) {
+    const div = document.createElement("div");
+    div.id = `component-${i}`;
+    document.body.appendChild(div);
+  }
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("mountAll", () => {
+  it("mounts all components in the record", () => {
+    const components: Record<string, Component> = {
+      "#component-1": { view: () => tags.div("Component 1") },
+      "#component-2": { view: () => tags.div("Component 2") },
+      "#component-3": { view: () => tags.div("Component 3") },
+      "#component-4": { view: () => tags.div("Component 4") },
+    };
+
+    mountAll(components);
+
+    for (let i = 1; i <= 4; i++) {
+      expect(getByText(document.body, `Component ${i}`)).toBeDefined();
+    }
+  });
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,9 @@
 import { bind } from "./bind";
-import { on, type OnEvents } from "./on";
 import { classes } from "./classes";
+import { mountAll } from "./mount-all";
+import { on, type OnEvents } from "./on";
 import { ternary } from "./ternary";
 
 import type { FormEvent } from "./types";
 
-export { bind, on, classes, ternary, type OnEvents, type FormEvent };
+export { bind, classes, mountAll, on, ternary, type FormEvent, type OnEvents };

--- a/src/mount-all.ts
+++ b/src/mount-all.ts
@@ -7,25 +7,27 @@ import { mount, type Component } from "@tentjs/tent";
  *
  * @example
  * ```ts
- * const components: Components = {
- *   "#component-1": Component1,
- *   ".component-2": Component2,
- *   "#component-3": Component3,
- * };
- *
- * mountAll(components);
+ * mountAll([
+ *   { target: ".target-1", component: Example1 },
+ *   { target: ".target-2", component: Example2 },
+ *   { target: ".target-3", component: Example3 },
+ * ]);
  * ```
  */
-function mountAll(components: Components): void {
-  for (const key in components) {
-    const Component = components[key];
-    const target = document.querySelector(key);
+function mountAll(components: ComponentConfig[]): void {
+  for (let i = 0; i < components.length; i++) {
+    const { target, component } = components[i];
+    const targetElement = document.querySelector(target);
 
-    mount(target, Component);
+    mount(targetElement, component);
   }
 }
 
 type Components = Record<Target, Component>;
+type ComponentConfig = {
+  target: Target;
+  component: Component;
+};
 type Target = string;
 
 export { mountAll };

--- a/src/mount-all.ts
+++ b/src/mount-all.ts
@@ -3,7 +3,7 @@ import { mount, type Component } from "@tentjs/tent";
 /**
  * Mount multiple components to their respective targets.
  *
- * @param {Components} components - A record of components and their targets.
+ * @param {ComponentConfig} components - An array of `ComponentConfig`'s.
  *
  * @example
  * ```ts
@@ -23,11 +23,6 @@ function mountAll(components: ComponentConfig[]): void {
   }
 }
 
-type Components = Record<Target, Component>;
-type ComponentConfig = {
-  target: Target;
-  component: Component;
-};
-type Target = string;
+type ComponentConfig = { target: string; component: Component };
 
 export { mountAll };

--- a/src/mount-all.ts
+++ b/src/mount-all.ts
@@ -1,0 +1,31 @@
+import { mount, type Component } from "@tentjs/tent";
+
+/**
+ * Mount multiple components to their respective targets.
+ *
+ * @param {Components} components - A record of components and their targets.
+ *
+ * @example
+ * ```ts
+ * const components: Components = {
+ *   "#component-1": Component1,
+ *   ".component-2": Component2,
+ *   "#component-3": Component3,
+ * };
+ *
+ * mountAll(components);
+ * ```
+ */
+function mountAll(components: Components): void {
+  for (const key in components) {
+    const Component = components[key];
+    const target = document.querySelector(key);
+
+    mount(target, Component);
+  }
+}
+
+type Components = Record<Target, Component>;
+type Target = string;
+
+export { mountAll };

--- a/src/mount-all.ts
+++ b/src/mount-all.ts
@@ -3,7 +3,7 @@ import { mount, type Component } from "@tentjs/tent";
 /**
  * Mount multiple components to their respective targets.
  *
- * @param {ComponentConfig} components - An array of `ComponentConfig`'s.
+ * @param {ComponentConfig[]} components - An array of `ComponentConfig`'s.
  *
  * @example
  * ```ts


### PR DESCRIPTION
# Description

Adds a `mountAll` helper function which mounts multiple components to their respective targets.

# Usage

```ts
import { mountAll } from "@tentjs/helpers";

mountAll([
  { target: ".target-1", component: Example1 },
  { target: ".target-2", component: Example2 },
  { target: ".target-3", component: Example3 },
]);
```